### PR TITLE
Add initial implementation of CompletionRequests 

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,7 @@ authors = ["Embyr"]
 
 [dependencies]
 ryst-openai = { path = "../openai", version = "=0.1.0" } # ryst-openai Version
+ryst-error = { path = "../error", version = "=0.1.0" } # ryst-error Version
 
 [features]
 default = []

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -12,10 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[workspace]
+[package]
+name = "ryst-error"
+version = "0.1.0"
+edition = "2021"
 
-members = [
-    "cli",
-    "error",
-    "openai",
+authors = ["Embyr"]
+
+[dependencies]
+
+[features]
+default = []
+stable = []
+experimental = [
+]
+
+[package.metadata.docs.rs]
+features = [
+  "stable",
+  "experimental"
 ]

--- a/error/src/cli.rs
+++ b/error/src/cli.rs
@@ -1,0 +1,39 @@
+// Copyright 2023 Embyr
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+/// CliError, the return type for main().
+///
+/// CliError does not implement Error because it is intended to only be used as the return type of
+/// main(), in order to implement Debug as required for proper display. Other errors should be
+/// converted to CliError within main() itself.
+pub struct CliError(String);
+
+impl fmt::Debug for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<E> From<E> for CliError
+where
+    E: std::error::Error,
+{
+    fn from(err: E) -> Self {
+        // trim_end() is used here because some errors, such as diesel::r2d2 errors can contain a
+        // newline
+        Self(err.to_string().trim_end().to_string())
+    }
+}

--- a/error/src/internal.rs
+++ b/error/src/internal.rs
@@ -1,0 +1,273 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Module containing InternalError implementation.
+
+use std::error;
+use std::fmt;
+use std::string::ToString;
+
+struct Source {
+    prefix: Option<String>,
+    source: Box<dyn error::Error>,
+}
+
+/// An error which is returned for reasons internal to the function.
+///
+/// This error is produced when a failure occurred within the function but the failure is due to an
+/// internal implementation detail of the function. This generally means that there is no specific
+/// information which can be returned that would help the caller of the function recover or
+/// otherwise take action.
+pub struct InternalError {
+    message: Option<String>,
+    source: Option<Source>,
+}
+
+impl InternalError {
+    /// Constructs a new `InternalError` from a specified source error.
+    ///
+    /// The implementation of `std::fmt::Display` for this error will simply pass through the
+    /// display of the source message unmodified.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ryst_error::InternalError;
+    ///
+    /// let io_err = std::io::Error::new(std::io::ErrorKind::Other, "io error");
+    /// let internal_error = InternalError::from_source(Box::new(io_err));
+    /// assert_eq!(format!("{}", internal_error), "io error");
+    /// ```
+    pub fn from_source(source: Box<dyn error::Error>) -> Self {
+        Self {
+            message: None,
+            source: Some(Source {
+                prefix: None,
+                source,
+            }),
+        }
+    }
+
+    /// Constructs a new `InternalError` from a specified source error and message string.
+    ///
+    /// The implementation of `std::fmt::Display` for this error will be the message string
+    /// provided.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ryst_error::InternalError;
+    ///
+    /// let io_err = std::io::Error::new(std::io::ErrorKind::Other, "io error");
+    /// let internal_error = InternalError::from_source_with_message(Box::new(io_err), "oops".to_string());
+    /// assert_eq!(format!("{}", internal_error), "oops");
+    /// ```
+    pub fn from_source_with_message<S: ToString>(
+        source: Box<dyn error::Error>,
+        message: S,
+    ) -> Self {
+        Self {
+            message: Some(message.to_string()),
+            source: Some(Source {
+                prefix: None,
+                source,
+            }),
+        }
+    }
+
+    /// Constructs a new `InternalError` from a specified source error and prefix string.
+    ///
+    /// The implementation of `std::fmt::Display` for this error will be constructed from the
+    /// prefix and source message's display following the format of `format!("{}: {}", prefix,
+    /// source)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ryst_error::InternalError;
+    ///
+    /// let io_err = std::io::Error::new(std::io::ErrorKind::Other, "io error");
+    /// let internal_error = InternalError::from_source_with_prefix(Box::new(io_err), "Could not open file".to_string());
+    /// assert_eq!(format!("{}", internal_error), "Could not open file: io error");
+    /// ```
+    pub fn from_source_with_prefix<S: ToString>(source: Box<dyn error::Error>, prefix: S) -> Self {
+        Self {
+            message: None,
+            source: Some(Source {
+                prefix: Some(prefix.to_string()),
+                source,
+            }),
+        }
+    }
+
+    /// Constructs a new `InternalError` with a specified message string.
+    ///
+    /// The implementation of `std::fmt::Display` for this error will be the message string
+    /// provided.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ryst_error::InternalError;
+    ///
+    /// let internal_error = InternalError::with_message("oops");
+    /// assert_eq!(format!("{}", internal_error), "oops");
+    /// ```
+    pub fn with_message<S: ToString>(message: S) -> Self {
+        Self {
+            message: Some(message.to_string()),
+            source: None,
+        }
+    }
+}
+
+impl error::Error for InternalError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        self.source.as_ref().map(|s| s.source.as_ref())
+    }
+}
+
+impl fmt::Display for InternalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.message {
+            Some(m) => f.write_str(m),
+            None => match &self.source {
+                Some(s) => match &s.prefix {
+                    Some(p) => write!(f, "{}: {}", p, s.source),
+                    None => s.source.fmt(f),
+                },
+                None => f.write_str(std::any::type_name::<InternalError>()),
+            },
+        }
+    }
+}
+
+impl fmt::Debug for InternalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut debug_struct = f.debug_struct("InternalError");
+
+        if let Some(message) = &self.message {
+            debug_struct.field("message", message);
+        }
+
+        if let Some(source) = &self.source {
+            if let Some(prefix) = &source.prefix {
+                debug_struct.field("prefix", prefix);
+            }
+
+            debug_struct.field("source", &source.source);
+        }
+
+        debug_struct.finish()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    /// Tests that errors constructed with `InternalError::from_source` return a debug string of
+    /// the form `format!("InternalError { {:?} }", source)`.
+    #[test]
+    fn test_debug_from_source() {
+        let msg = "test message";
+        let debug = "InternalError { source: InternalError { message: \"test message\" } }";
+        let err =
+            InternalError::from_source(Box::new(InternalError::with_message(msg.to_string())));
+        assert_eq!(format!("{:?}", err), debug);
+    }
+
+    /// Tests that errors constructed with `InternalError::from_source_with_message` return a debug
+    /// string of the form `format!("InternalError { message: {:?}, source: {:?} }", message,
+    /// source)`.
+    #[test]
+    fn test_debug_from_source_with_message() {
+        let msg = "test message";
+        let debug = "InternalError { message: \"test message\", source: InternalError { message: \"unused\" } }";
+        let err = InternalError::from_source_with_message(
+            Box::new(InternalError::with_message("unused".to_string())),
+            msg.to_string(),
+        );
+        assert_eq!(format!("{:?}", err), debug);
+    }
+
+    /// Tests that errors constructed with `InternalError::from_source_with_prefix` return a debug
+    /// string of the form `format!("InternalError { prefix: {:?}, source: {:?} }", prefix,
+    /// source)`.
+    #[test]
+    fn test_debug_from_source_with_prefix() {
+        let prefix = "test prefix";
+        let msg = "test message";
+        let debug = "InternalError { prefix: \"test prefix\", source: InternalError { message: \"test message\" } }";
+        let err = InternalError::from_source_with_prefix(
+            Box::new(InternalError::with_message(msg.to_string())),
+            prefix.to_string(),
+        );
+        assert_eq!(format!("{:?}", err), debug);
+    }
+
+    /// Tests that errors constructed with `InternalError::with_message` return a debug
+    /// string of the form `format!("InternalError { message: {:?} }", message)`.
+    #[test]
+    fn test_debug_with_message() {
+        let msg = "test message";
+        let debug = "InternalError { message: \"test message\" }";
+        let err = InternalError::with_message(msg.to_string());
+        assert_eq!(format!("{:?}", err), debug);
+    }
+
+    /// Tests that error constructed with `InternalError::from_source` return a display
+    /// string which is the same as the source's display string.
+    #[test]
+    fn test_display_from_source() {
+        let msg = "test message";
+        let err =
+            InternalError::from_source(Box::new(InternalError::with_message(msg.to_string())));
+        assert_eq!(format!("{}", err), msg);
+    }
+
+    /// Tests that error constructed with `InternalError::from_source_with_message` return
+    /// message as the display string.
+    #[test]
+    fn test_display_from_source_with_message() {
+        let msg = "test message";
+        let err = InternalError::from_source_with_message(
+            Box::new(InternalError::with_message("unused".to_string())),
+            msg.to_string(),
+        );
+        assert_eq!(format!("{}", err), msg);
+    }
+
+    /// Tests that error constructed with `InternalError::from_source_with_message` return
+    /// a display string of the form `format!("{}: {}", prefix, source)`.
+    #[test]
+    fn test_display_from_source_with_prefix() {
+        let prefix = "test prefix";
+        let msg = "test message";
+        let err = InternalError::from_source_with_prefix(
+            Box::new(InternalError::with_message(msg.to_string())),
+            prefix.to_string(),
+        );
+        assert_eq!(format!("{}", err), format!("{}: {}", prefix, msg));
+    }
+
+    /// Tests that error constructed with `InternalError::with_message` return message as the
+    /// display string.
+    #[test]
+    fn test_display_with_message() {
+        let msg = "test message";
+        let err = InternalError::with_message(msg.to_string());
+        assert_eq!(format!("{}", err), msg);
+    }
+}

--- a/error/src/invalid_argument.rs
+++ b/error/src/invalid_argument.rs
@@ -1,0 +1,87 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Module containing InvalidArgumentError implementation.
+
+use std::error;
+use std::fmt;
+
+/// An error returned when an argument passed to a function does not conform to the expected format.
+///
+/// This always indicates a programming error on behalf of the caller, since the caller should have
+/// verified the argument prior to passing it into the function.
+#[derive(Debug)]
+pub struct InvalidArgumentError {
+    argument: String,
+    message: String,
+}
+
+impl InvalidArgumentError {
+    /// Constructs a new `InvalidArgumentError` with a specified argument and message string.
+    ///
+    /// The argument passed in should be the name of the argument in the function's signature. The
+    /// message should be the reason it is invalid, and should not contain the name of the argument
+    /// (since Display will combine both argument and message).
+    ///
+    /// The implementation of `std::fmt::Display` for this error will be a combination of the
+    /// argument and the message string provided.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ryst_error::InvalidArgumentError;
+    ///
+    /// let invalid_arg_error = InvalidArgumentError::new("arg1", "argument too long");
+    /// assert_eq!(format!("{}", invalid_arg_error), "argument too long (arg1)");
+    /// ```
+    pub fn new<T1: Into<String>, T2: Into<String>>(argument: T1, message: T2) -> Self {
+        Self {
+            argument: argument.into(),
+            message: message.into(),
+        }
+    }
+
+    /// Returns the name of the invalid argument.
+    pub fn argument(&self) -> String {
+        self.argument.clone()
+    }
+
+    /// Returns the message, which is an explanation of why the argument is invalid.
+    pub fn message(&self) -> String {
+        self.message.clone()
+    }
+}
+
+impl error::Error for InvalidArgumentError {}
+
+impl fmt::Display for InvalidArgumentError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} ({})", &self.message, &self.argument)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    /// Tests that error constructed with `InvalidArgumentError::new` return message as the
+    /// display string.
+    #[test]
+    fn test_display() {
+        let arg = "arg1";
+        let msg = "test message";
+        let err = InvalidArgumentError::new(arg.to_string(), msg.to_string());
+        assert_eq!(format!("{}", err), format!("{} ({})", msg, arg));
+    }
+}

--- a/error/src/invalid_state.rs
+++ b/error/src/invalid_state.rs
@@ -1,0 +1,71 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Module containing InvalidStateError implementation.
+
+use std::error;
+use std::fmt;
+
+/// An error returned when an operation cannot be completed because the state of the underlying
+/// struct is inconsistent.
+///
+/// This can be caused by a caller when a sequence of functions is called in a way that results in
+/// a state which is inconsistent.
+///
+/// This usually indicates a programming error on behalf of the caller.
+#[derive(Debug)]
+pub struct InvalidStateError {
+    message: String,
+}
+
+impl InvalidStateError {
+    /// Constructs a new `InvalidStateError` with a specified message string.
+    ///
+    /// The implementation of `std::fmt::Display` for this error will be the message string
+    /// provided.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ryst_error::InvalidStateError;
+    ///
+    /// let invalid_state_error = InvalidStateError::with_message("oops".to_string());
+    /// assert_eq!(format!("{}", invalid_state_error), "oops");
+    /// ```
+    pub fn with_message(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl error::Error for InvalidStateError {}
+
+impl fmt::Display for InvalidStateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.message)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    /// Tests that error constructed with `InvalidStateError::with_message` return message as the
+    /// display string.
+    #[test]
+    fn test_display_with_message() {
+        let msg = "test message";
+        let err = InvalidStateError::with_message(msg.to_string());
+        assert_eq!(format!("{}", err), msg);
+    }
+}

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod cli;
+mod internal;
+mod invalid_argument;
+mod invalid_state;
+
+pub use cli::CliError;
+pub use internal::InternalError;
+pub use invalid_argument::InvalidArgumentError;
+pub use invalid_state::InvalidStateError;

--- a/justfile
+++ b/justfile
@@ -34,6 +34,11 @@ build:
     do
         for crate in $(echo {{crates}})
         do
+            if [ "$crate" = "openai" ] && [ "$feature" != "--no-default-features" ]; then
+                cmd="cargo build --tests --manifest-path=$crate/Cargo.toml $BUILD_MODE $feature,integration"
+                echo "\033[1m$cmd\033[0m"
+                $cmd
+            fi
             cmd="cargo build --tests --manifest-path=$crate/Cargo.toml $feature"
             echo "\033[1m$cmd\033[0m"
             $cmd

--- a/justfile
+++ b/justfile
@@ -16,6 +16,7 @@
 
 crates := '\
     openai \
+    error \
     cli
     '
 

--- a/openai/Cargo.toml
+++ b/openai/Cargo.toml
@@ -20,6 +20,13 @@ edition = "2021"
 authors = ["Embyr"]
 
 [dependencies]
+reqwest = { version = "0.11", features = ["json", "stream"]}
+ryst-error = { path = "../error", version = "=0.1.0" } # ryst-error Version
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros"] }
 
 [features]
 default = []

--- a/openai/Cargo.toml
+++ b/openai/Cargo.toml
@@ -20,6 +20,8 @@ edition = "2021"
 authors = ["Embyr"]
 
 [dependencies]
+bytes = "1.4"
+futures = "0.3"
 reqwest = { version = "0.11", features = ["json", "stream"]}
 ryst-error = { path = "../error", version = "=0.1.0" } # ryst-error Version
 serde = { version = "1", features = ["derive"] }

--- a/openai/Cargo.toml
+++ b/openai/Cargo.toml
@@ -41,6 +41,9 @@ experimental = [
   # The following features are experimental:
 ]
 
+# turns on integration tests
+integration = []
+
 [package.metadata.docs.rs]
 features = [
   "stable",

--- a/openai/src/completion/mod.rs
+++ b/openai/src/completion/mod.rs
@@ -1,0 +1,108 @@
+// Copyright 2023 Embyr
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module contains a set of structs for communicating with OpenAI
+//! completions API.
+
+mod request;
+mod response;
+
+pub use request::CompletionRequest;
+pub use response::{Choice, CompletionResponse, Usage};
+
+// The following tests require that OPENAI_API_KEY (optionally OPENAI_API_ORG)
+// are set. We are using the "ada" model as this is the cheapest and the tests
+// will burn tokens.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    // Verify that a simple completion returns a completion response
+    async fn test_completion() {
+        let response = CompletionRequest::new("ada", "Say this is a test")
+            .submit()
+            .await
+            .unwrap();
+
+        assert!(!response.choices.is_empty());
+    }
+
+    #[tokio::test]
+    // Verify that a simple completion with logprobs returns with logprobs correctly
+    async fn test_completion_logprobs() {
+        let response = CompletionRequest::new("ada", "Say this is a test")
+            .with_logprobs(1)
+            .submit()
+            .await
+            .unwrap();
+
+        assert!(response.choices[0].logprobs.is_some());
+    }
+
+    #[tokio::test]
+    // Verify that a complicated completion returns as expected
+    async fn test_completion_max_tokens_n_echo() {
+        let response = CompletionRequest::new("ada", "Say this is a test")
+            .with_max_tokens(15)
+            .with_temperature(0.0)
+            .with_n(2)
+            .with_echo(true)
+            .submit()
+            .await
+            .unwrap();
+
+        assert!(response.choices.len() == 2);
+        assert!(response.choices[0].text.starts_with("Say this is a test"));
+        // max tokens * 2 options
+        assert!(response.usage.completion_tokens <= 30);
+        assert!(response.choices[0].text == response.choices[1].text);
+    }
+
+    #[tokio::test]
+    // Verify that a complicated completion returns as expected
+    async fn test_completion_stop_penalty_best_of_user() {
+        let response = CompletionRequest::new("ada", "Say this is a test")
+            .with_stop("test")
+            .with_max_tokens(15)
+            .with_presence_penalty(-2.0)
+            .with_frequency_penalty(-2.0)
+            .with_best_of(2)
+            .with_user("USER_A")
+            .submit()
+            .await
+            .unwrap();
+
+        assert!(!response.choices.is_empty());
+    }
+
+    #[tokio::test]
+    // Verify that a complicated completion returns as expected
+    async fn test_completion_top_p_logit_bias() {
+        // prevents  <|endoftext|> token from being generated
+        let bias: HashMap<String, i8> = HashMap::from([("50256".to_string(), -100)]);
+
+        let response = CompletionRequest::new("ada", "Say this is a test")
+            .with_top_p(0.1)
+            .with_max_tokens(15)
+            .with_logit_bias(&bias)
+            .submit()
+            .await
+            .unwrap();
+
+        assert!(!response.choices.is_empty());
+    }
+}

--- a/openai/src/completion/mod.rs
+++ b/openai/src/completion/mod.rs
@@ -24,6 +24,7 @@ pub use response::{Choice, CompletionResponse, Usage};
 // The following tests require that OPENAI_API_KEY (optionally OPENAI_API_ORG)
 // are set. We are using the "ada" model as this is the cheapest and the tests
 // will burn tokens.
+#[cfg(feature = "integration")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/openai/src/completion/request.rs
+++ b/openai/src/completion/request.rs
@@ -1,0 +1,250 @@
+// Copyright 2023 Embyr
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::env;
+
+use reqwest::Client;
+use ryst_error::{InternalError, InvalidArgumentError, InvalidStateError};
+use serde::Serialize;
+
+use crate::error::OpenAIError;
+use crate::OPEN_AI_URL;
+
+use super::CompletionResponse;
+
+/// Builder for creating the completion request and submitting to OpenAI API.
+#[derive(Debug, Serialize, PartialEq, Default)]
+pub struct CompletionRequest {
+    model: String,
+    prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suffix: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    n: Option<i8>,
+    // not currently supported
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    logprobs: Option<i8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    echo: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    presence_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frequency_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    best_of: Option<i8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    logit_bias: Option<HashMap<String, i8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user: Option<String>,
+}
+
+impl CompletionRequest {
+    /// Create a new `CompletionRequest` builder
+    ///
+    /// Takes a model and prompt, as these are always required.
+    pub fn new(model: &str, prompt: &str) -> Self {
+        CompletionRequest {
+            model: model.to_string(),
+            prompt: prompt.to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// Submit the completion request to the OpenAI url.
+    ///
+    /// Requires that `OPENAI_API_KEY` environment variable is set. Optionally,
+    /// the org will be added if `OPENAI_API_ORG` is set.
+    pub async fn submit(self) -> Result<CompletionResponse, OpenAIError> {
+        let api_key = env::var("OPENAI_API_KEY").map_err(|_| {
+            OpenAIError::InvalidState(InvalidStateError::with_message(
+                "OPENAI_API_KEY env variable must be set".to_string(),
+            ))
+        })?;
+
+        let mut request = Client::new()
+            .post(format!("{OPEN_AI_URL}/v1/completions"))
+            .header("Authorization", format!("Bearer {api_key}"))
+            .header("Content-Type", "application/json")
+            .json(&self);
+
+        if let Ok(org) = env::var("OPENAI_API_ORG") {
+            request = request.header("OpenAI-Organization", org)
+        };
+
+        if let Some(stops) = self.stop {
+            if stops.len() > 4 {
+                return Err(OpenAIError::InvalidArgument(InvalidArgumentError::new(
+                    "stop",
+                    "You can only provide up to 4 stop sequences",
+                )));
+            }
+        }
+
+        if self.temperature.is_some() && self.top_p.is_some() {
+            return Err(OpenAIError::InvalidArgument(InvalidArgumentError::new(
+                "temperature",
+                "Use temperature or top_p but not both",
+            )));
+        }
+
+        match request.send().await {
+            Ok(response) => {
+                // Check if the status is a 2XX code.
+                let status = response.status();
+                if status.is_success() {
+                    let result = response.json::<CompletionResponse>().await.map_err(|err| {
+                        OpenAIError::InvalidState(InvalidStateError::with_message(err.to_string()))
+                    })?;
+                    Ok(result)
+                } else {
+                    let text = response.text().await.map_err(|err| {
+                        OpenAIError::InvalidState(InvalidStateError::with_message(err.to_string()))
+                    })?;
+                    if status.is_client_error() {
+                        Err(OpenAIError::InvalidArgument(InvalidArgumentError::new(
+                            "request", text,
+                        )))
+                    } else {
+                        Err(OpenAIError::Internal(InternalError::with_message(text)))
+                    }
+                }
+            }
+            Err(err) => Err(OpenAIError::Internal(InternalError::from_source(Box::new(
+                err,
+            )))),
+        }
+    }
+
+    /// Add a suffix that comes after a completion of inserted text.
+    ///
+    /// Only works with some models.
+    pub fn with_suffix(mut self, suffix: &str) -> Self {
+        self.suffix = Some(suffix.to_string());
+        self
+    }
+
+    /// The maximum number of tokens to generate in the completion.
+    pub fn with_max_tokens(mut self, max_tokens: i32) -> Self {
+        self.max_tokens = Some(max_tokens);
+        self
+    }
+
+    /// What sampling temperature to use
+    ///
+    /// This should not be used at the same time with top_p
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.temperature = Some(temperature);
+        self
+    }
+
+    /// Nucleus sampling value
+    ///
+    /// Where the model considers the results of the tokens with top_p probability mass.
+    /// This should not be used at the same time with temperature
+    pub fn with_top_p(mut self, top_p: f32) -> Self {
+        self.top_p = Some(top_p);
+        self
+    }
+
+    /// How many completions to generate for each prompt.
+    pub fn with_n(mut self, n: i8) -> Self {
+        self.n = Some(n);
+        self
+    }
+
+    /// Include the log probabilities on the logprobs most likely tokens, as well the chosen tokens.
+    pub fn with_logprobs(mut self, logprobs: i8) -> Self {
+        self.logprobs = Some(logprobs);
+        self
+    }
+
+    /// Echo back the prompt in addition to the completion
+    pub fn with_echo(mut self, echo: bool) -> Self {
+        self.echo = Some(echo);
+        self
+    }
+
+    /// The sequence where the API will stop generating further tokens.
+    ///
+    /// The returned text will not contain the stop sequence. Use of `with_stops` will overwrite this
+    /// value.
+    pub fn with_stop(mut self, stop: &str) -> Self {
+        self.stop = Some(vec![stop.to_string()]);
+        self
+    }
+
+    /// Up to 4 sequences where the API will stop generating further tokens.
+    ///
+    /// The returned text will not contain the stop sequence. Use of `with_stop` will overwrite this
+    /// value.
+    pub fn with_stops(mut self, stop: &[String]) -> Self {
+        self.stop = Some(stop.to_vec());
+        self
+    }
+
+    /// Positive values penalize new tokens based on whether they appear in the text so far.
+    ///
+    /// This increases the model's likelihood to talk about new topics.
+    /// Takes a number between -2.0 and 2.0
+    pub fn with_presence_penalty(mut self, presence_penalty: f32) -> Self {
+        self.presence_penalty = Some(presence_penalty);
+        self
+    }
+
+    /// Positive values penalize new tokens based on their existing frequency in the text so far.
+    ///
+    /// Decreases the model's likelihood to repeat the same line verbatim.
+    /// Takes a number between -2.0 and 2.0
+    pub fn with_frequency_penalty(mut self, frequency_penalty: f32) -> Self {
+        self.frequency_penalty = Some(frequency_penalty);
+        self
+    }
+
+    /// Generates best_of completions server-side and returns the "best"
+    ///
+    /// The one with the highest log probability per token. Results cannot be streamed.
+    pub fn with_best_of(mut self, best_of: i8) -> Self {
+        self.best_of = Some(best_of);
+        self
+    }
+
+    /// Modify the likelihood of specified tokens appearing in the completion.
+    ///
+    /// Accepts a json object that maps tokens (specified by their token ID in the GPT tokenizer)
+    /// to an associated bias value from -100 to 100.
+    ///
+    /// As an example, you can pass `{"50256": -100}` to prevent the `<|endoftext|>` token from
+    /// being generated.
+    pub fn with_logit_bias(mut self, logit_bias: &HashMap<String, i8>) -> Self {
+        self.logit_bias = Some(logit_bias.clone());
+        self
+    }
+
+    /// A unique ID representing your end-user, which can help OpenAI to monitor and detect abuse.
+    pub fn with_user(mut self, user: &str) -> Self {
+        self.user = Some(user.to_string());
+        self
+    }
+}

--- a/openai/src/completion/response.rs
+++ b/openai/src/completion/response.rs
@@ -1,0 +1,94 @@
+// Copyright 2023 Embyr
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use serde::de::{Deserializer, Visitor};
+use serde::Deserialize;
+
+/// The response returned from a completion request.
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct CompletionResponse {
+    /// Request ID
+    pub id: String,
+    /// Response type
+    pub object: String,
+    /// Timestamp of the completion was created
+    pub created: i32,
+    /// The model the response was created with
+    pub model: String,
+    /// The list of generated completions
+    pub choices: Vec<Choice>,
+    /// The tokens used by this response and associated request
+    pub usage: Usage,
+}
+
+/// The tokens consumed by the completion
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Usage {
+    pub prompt_tokens: i32,
+    pub completion_tokens: i32,
+    pub total_tokens: i32,
+}
+
+/// A generated completion
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Choice {
+    pub text: String,
+    pub index: i32,
+    pub logprobs: Option<Logprobs>,
+    pub finish_reason: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Logprobs {
+    pub tokens: Vec<String>,
+    pub token_logprobs: Vec<f32>,
+    #[serde(deserialize_with = "flatten_log_probs")]
+    pub top_logprobs: HashMap<String, f32>,
+    pub text_offset: Vec<i32>,
+}
+
+fn flatten_log_probs<'de, D>(deserializer: D) -> Result<HashMap<String, f32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct LogProbsVisitor;
+
+    impl<'de> Visitor<'de> for LogProbsVisitor {
+        type Value = HashMap<String, f32>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a sequence of maps")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut result = HashMap::new();
+
+            while let Some(map) = seq.next_element::<HashMap<String, f32>>()? {
+                for (key, value) in map {
+                    result.insert(key, value);
+                }
+            }
+
+            Ok(result)
+        }
+    }
+
+    deserializer.deserialize_seq(LogProbsVisitor)
+}

--- a/openai/src/error.rs
+++ b/openai/src/error.rs
@@ -1,0 +1,51 @@
+// Copyright 2023 Embyr
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Module containing OpenAIError implementation.
+
+use std::error::Error;
+
+use ryst_error::{InternalError, InvalidArgumentError, InvalidStateError};
+
+/// Returned when an error occurs using the SDK.
+#[derive(Debug)]
+pub enum OpenAIError {
+    /// An error which is returned for reasons internal to the function.
+    Internal(InternalError),
+    /// An error returned when an argument passed to a function does not match the expected format.
+    InvalidArgument(InvalidArgumentError),
+    /// An error returned when an operation cannot be completed because the state of the underlying
+    // struct is inconsistent.
+    InvalidState(InvalidStateError),
+}
+
+impl Error for OpenAIError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            OpenAIError::Internal(e) => Some(e),
+            OpenAIError::InvalidArgument(e) => Some(e),
+            OpenAIError::InvalidState(e) => Some(e),
+        }
+    }
+}
+
+impl std::fmt::Display for OpenAIError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            OpenAIError::Internal(e) => e.fmt(f),
+            OpenAIError::InvalidArgument(e) => e.fmt(f),
+            OpenAIError::InvalidState(e) => e.fmt(f),
+        }
+    }
+}

--- a/openai/src/lib.rs
+++ b/openai/src/lib.rs
@@ -1,1 +1,25 @@
+// Copyright 2023 Embyr
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+//! SDK for the OpenAI API
+
+extern crate serde;
+
+mod completion;
+mod error;
+
+const OPEN_AI_URL: &str = "https://api.openai.com";
+
+pub use completion::{Choice, CompletionRequest, CompletionResponse, Usage};
+pub use error::OpenAIError;

--- a/openai/src/lib.rs
+++ b/openai/src/lib.rs
@@ -21,5 +21,7 @@ mod error;
 
 const OPEN_AI_URL: &str = "https://api.openai.com";
 
-pub use completion::{Choice, CompletionRequest, CompletionResponse, Usage};
+pub use completion::{
+    Choice, CompletionRequest, CompletionResponse, CompletionResponseStream, Usage,
+};
 pub use error::OpenAIError;


### PR DESCRIPTION
Adds a builder (CompletionRequest) for building the request
to be sent to the OpenAI API and return the generated response
(CompletionResponse).

All request options found [here](https://platform.openai.com/docs/api-reference/completions/create)
are supported except for streaming the request (this will be added in the future)

This commit also adds tests that require setting the OPENAI_API_KEY env
variable. The tests do submit real requests to the OpenAI API and will consume
tokens. However, the tests are written againts the cheapest (and most simple)
model ada.
