### PR TITLE
Revert "Add just version-check to rust build"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,5 +34,3 @@ jobs:
         run: just build
       - name: Run tests
         run: just test
-      - name: Check Versions
-        run: just version-check


### PR DESCRIPTION
This reverts commit c3edee219566f496a98d67135348a5b01bc08da6.

This check is already ran before `just lint` so this check is redundant.